### PR TITLE
Add ability to configure cache options w/ defaults

### DIFF
--- a/lib/active_remote/cached/railtie.rb
+++ b/lib/active_remote/cached/railtie.rb
@@ -1,9 +1,19 @@
+require 'active_support/ordered_options'
+
 module ActiveRemote
   module Cached
     class Railtie < Rails::Railtie
+      config.active_remote_cached = ActiveSupport::OrderedOptions.new
+
       initializer "active_remote-cached.initialize_cache" do |app|
+        config.active_remote_cached.expires_in ||= 5.minutes
+        config.active_remote_cached.race_condition_ttl ||= 5.seconds
+
         ActiveRemote::Cached.cache(Rails.cache)
-        ActiveRemote::Cached.default_options(:race_condition_ttl => 5.seconds)
+        ActiveRemote::Cached.default_options(
+          :expires_in         => config.active_remote_cached.expires_in,
+          :race_condition_ttl => config.active_remote_cached.race_condition_ttl
+        )
       end
 
       ActiveSupport.on_load(:active_remote) do


### PR DESCRIPTION
In Rails apps, provide a config object that can be used to set the default `expires_in` and `race_condition_ttl` options used when writing to the cache. If no value is specified, `expires_in` defaults to 5 minutes and `race_condition_ttl` defaults to 5 seconds.
