### PR TITLE
Proof of concept: add the ability to perform nested caching

### DIFF
--- a/lib/active_remote/cached/railtie.rb
+++ b/lib/active_remote/cached/railtie.rb
@@ -2,22 +2,27 @@ require 'active_support/ordered_options'
 
 module ActiveRemote
   module Cached
-    class Railtie < Rails::Railtie
-      config.active_remote_cached = ActiveSupport::OrderedOptions.new
+    class Railtie < ::Rails::Railtie
+      config.active_remote_cached = ::ActiveSupport::OrderedOptions.new
 
       initializer "active_remote-cached.initialize_cache" do |app|
         config.active_remote_cached.expires_in ||= 5.minutes
         config.active_remote_cached.race_condition_ttl ||= 5.seconds
 
-        ActiveRemote::Cached.cache(Rails.cache)
-        ActiveRemote::Cached.default_options(
+        ::ActiveRemote::Cached.cache(Rails.cache)
+
+        if config.active_remote_cached.enable_nested_caching
+          ::ActiveRemote::Cached.cache.enable_nested_caching!
+        end
+
+        ::ActiveRemote::Cached.default_options(
           :expires_in         => config.active_remote_cached.expires_in,
           :race_condition_ttl => config.active_remote_cached.race_condition_ttl
         )
       end
 
-      ActiveSupport.on_load(:active_remote) do
-        include ActiveRemote::Cached
+      ::ActiveSupport.on_load(:active_remote) do
+        include ::ActiveRemote::Cached
       end
     end
   end


### PR DESCRIPTION
This is a proof of concept for supporting nested caching. The basic idea is that if we can support a local store and a shared global store, we get the benefits of both. The local store means that multiple threads can share a cached item and avoid checking the global store (i.e. Redis, Memcached), but multiple nodes can still share a cached item using the global store.

I'm not completely sold on this implementation, but I think it adequately illustrates how something like this could be accomplished. It essentially depends on using the [null store](http://api.rubyonrails.org/classes/ActiveSupport/Cache/NullStore.html) by default to always perform nested cache lookups. The null store is affectively a no-op, so all `exist?`, `fetch` and `read` calls will result in a miss, which will fall through to the configured cache store. Enabling nested caching simply replaces the null store with a [memory store](http://api.rubyonrails.org/classes/ActiveSupport/Cache/MemoryStore.html). Because the cache paths always check the that store first, we get nested caching.

// @mmmries @abrandoned @brianstien