### PR TITLE
allow options to be set at the model level

### DIFF
--- a/spec/active_remote/cached_find_methods_spec.rb
+++ b/spec/active_remote/cached_find_methods_spec.rb
@@ -6,6 +6,7 @@ class FindMethodClass
   def self.find; nil; end
   def self.search; nil; end
 
+  cached_finders_for :foo, :expires_in => 500
   cached_finders_for :guid
   cached_finders_for :guid, :user_guid
   cached_finders_for [:user_guid, :client_guid]
@@ -14,6 +15,10 @@ end
 
 describe FindMethodClass do
   describe "API" do
+    it "creates 'cached_find_by_foo'" do
+      FindMethodClass.must_respond_to("cached_find_by_foo")
+    end
+
     it "creates 'cached_find_by_guid'" do
       FindMethodClass.must_respond_to("cached_find_by_guid")
     end
@@ -92,6 +97,33 @@ describe FindMethodClass do
         FindMethodClass.stub(:find, :hello) do
           FindMethodClass.cached_find_by_guid(:guid)
         end
+      end
+    end
+  end
+
+  describe "#cached_find_by_foo" do
+    before do
+      ::ActiveRemote::Cached.cache(HashCache.new)
+      ::ActiveRemote::Cached.default_options(:expires_in => 100)
+    end
+
+    after do
+      ::ActiveRemote::Cached.default_options({})
+    end
+
+    it "overrides the default options with cached_finder options for the fetch call" do
+      ::ActiveRemote::Cached.cache.expects(:fetch).with([FindMethodClass.name, "#find", :foo], :expires_in => 500).returns(:hello)
+
+      FindMethodClass.stub(:find, :hello) do
+        FindMethodClass.cached_find_by_foo(:foo).must_equal(:hello)
+      end
+    end
+
+    it "overrides the cached_finder options with local options for the fetch call" do
+      ::ActiveRemote::Cached.cache.expects(:fetch).with([FindMethodClass.name, "#find", :foo], :expires_in => 200).returns(:hello)
+
+      FindMethodClass.stub(:find, :hello) do
+        FindMethodClass.cached_find_by_foo(:foo, :expires_in => 200).must_equal(:hello)
       end
     end
   end

--- a/spec/active_remote/cached_search_methods_spec.rb
+++ b/spec/active_remote/cached_search_methods_spec.rb
@@ -7,6 +7,7 @@ class SearchMethodClass
   def self.find; nil; end
   def self.search; nil; end
 
+  cached_finders_for :foo, :expires_in => 500
   cached_finders_for :guid
   cached_finders_for :guid, :user_guid
   cached_finders_for [:user_guid, :client_guid]
@@ -15,6 +16,10 @@ end
 
 describe SearchMethodClass do
   describe "API" do
+    it "creates 'cached_search_by_foo'" do
+      SearchMethodClass.must_respond_to("cached_search_by_foo")
+    end
+
     it "creates 'cached_search_by_guid'" do
       SearchMethodClass.must_respond_to("cached_search_by_guid")
     end
@@ -141,6 +146,33 @@ describe SearchMethodClass do
         SearchMethodClass.stub(:search, :hello) do
           SearchMethodClass.cached_search_by_guid(:guid)
         end
+      end
+    end
+  end
+
+  describe "#cached_search_by_foo" do
+    before do
+      ::ActiveRemote::Cached.cache(HashCache.new)
+      ::ActiveRemote::Cached.default_options(:expires_in => 100)
+    end
+
+    after do
+      ::ActiveRemote::Cached.default_options({})
+    end
+
+    it "overrides the default options with cached_finder options for the fetch call" do
+      ::ActiveRemote::Cached.cache.expects(:fetch).with([SearchMethodClass.name, "#search", :foo], :expires_in => 500).returns(:hello)
+
+      SearchMethodClass.stub(:find, :hello) do
+        SearchMethodClass.cached_search_by_foo(:foo).must_equal(:hello)
+      end
+    end
+
+    it "overrides the cached_finder options with local options for the fetch call" do
+      ::ActiveRemote::Cached.cache.expects(:fetch).with([SearchMethodClass.name, "#search", :foo], :expires_in => 200).returns(:hello)
+
+      SearchMethodClass.stub(:find, :hello) do
+        SearchMethodClass.cached_search_by_foo(:foo, :expires_in => 200).must_equal(:hello)
       end
     end
   end


### PR DESCRIPTION
resolves https://github.com/abrandoned/active_remote-cached/issues/9

this will allow options to be passed in at the model level so we don't always have to pass the same options in anytime we want to use a cached_finder

For example
```
class Example
  include ::ActiveRemote::Cached

  cached_finders_for :guid, :expires_in => 500
end
```

Now we can do
```
Example.cached_find_by_guid("EXM-123")
```

and it will expire after 500 seconds instead of whatever the default is set to. but we can still override this with local options if we want
```
Example.cached_find_by_guid("EXM-123", :expires_in => 1000)
```

@abrandoned @mmmries @liveh2o 