### PR TITLE
Abrandoned/argument keys

### DIFF
--- a/lib/active_remote/cached.rb
+++ b/lib/active_remote/cached.rb
@@ -3,6 +3,7 @@ require "active_support/cache"
 require "active_support/concern"
 require "active_support/core_ext/array/extract_options"
 
+require "active_remote/cached/argument_keys"
 require "active_remote/cached/cache"
 require "active_remote/cached/version"
 require "active_remote/errors"
@@ -142,8 +143,19 @@ module ActiveRemote
           def self.#{method_name}(#{expanded_method_args}, __active_remote_cached_options = {})
             __active_remote_cached_options = ::ActiveRemote::Cached.default_options.merge(#{cached_finder_options}).merge(__active_remote_cached_options)
             namespace = __active_remote_cached_options.delete(:namespace)
-            find_cache_key = [namespace, name, "#find", #{sorted_method_args}].compact
-            search_cache_key = [namespace, name, "#search", #{sorted_method_args}].compact
+            find_cache_key = [
+              namespace,
+              name,
+              "#find",
+              ::ActiveRemote::Cached::ArgumentKeys.new(#{sorted_method_args}, __active_remote_cached_options).cache_key
+            ].compact
+
+            search_cache_key = [
+              namespace,
+              name,
+              "#search",
+              ::ActiveRemote::Cached::ArgumentKeys.new(#{sorted_method_args}, __active_remote_cached_options).cache_key
+            ].compact
 
             ::ActiveRemote::Cached.cache.delete(find_cache_key)
             ::ActiveRemote::Cached.cache.delete(search_cache_key)
@@ -163,7 +175,12 @@ module ActiveRemote
           def self.#{method_name}(#{expanded_method_args}, __active_remote_cached_options = {})
             __active_remote_cached_options = ::ActiveRemote::Cached.default_options.merge(#{cached_finder_options}).merge(__active_remote_cached_options)
             namespace = __active_remote_cached_options.delete(:namespace)
-            cache_key = [namespace, name, "#find", #{sorted_method_args}].compact
+            cache_key = [
+              namespace,
+              name,
+              "#find",
+              ::ActiveRemote::Cached::ArgumentKeys.new(#{sorted_method_args}, __active_remote_cached_options).cache_key
+            ].compact
 
             ::ActiveRemote::Cached.cache.exist?(cache_key)
           end
@@ -184,7 +201,12 @@ module ActiveRemote
           def self.#{method_name}(#{expanded_method_args}, __active_remote_cached_options = {})
             __active_remote_cached_options = ::ActiveRemote::Cached.default_options.merge(#{cached_finder_options}).merge(__active_remote_cached_options)
             namespace = __active_remote_cached_options.delete(:namespace)
-            cache_key = [namespace, name, "#search", #{sorted_method_args}].compact
+            cache_key = [
+              namespace,
+              name,
+              "#search",
+              ::ActiveRemote::Cached::ArgumentKeys.new(#{sorted_method_args}, __active_remote_cached_options).cache_key
+            ].compact
 
             ::ActiveRemote::Cached.cache.exist?(cache_key)
           end
@@ -218,7 +240,12 @@ module ActiveRemote
           def self.#{method_name}(#{expanded_method_args}, __active_remote_cached_options = {})
             __active_remote_cached_options = ::ActiveRemote::Cached.default_options.merge(#{cached_finder_options}).merge(__active_remote_cached_options)
             namespace = __active_remote_cached_options.delete(:namespace)
-            cache_key = [namespace, name, "#find", #{sorted_method_args}].compact
+            cache_key = [
+              namespace,
+              name,
+              "#find",
+              ::ActiveRemote::Cached::ArgumentKeys.new(#{sorted_method_args}, __active_remote_cached_options).cache_key
+            ].compact
 
             ::ActiveRemote::Cached.cache.fetch(cache_key, __active_remote_cached_options) do
               if block_given?
@@ -260,7 +287,12 @@ module ActiveRemote
           def self.#{method_name}(#{expanded_method_args}, __active_remote_cached_options = {})
             __active_remote_cached_options = ::ActiveRemote::Cached.default_options.merge(#{cached_finder_options}).merge(__active_remote_cached_options)
             namespace = __active_remote_cached_options.delete(:namespace)
-            cache_key = [namespace, name, "#search", #{sorted_method_args}].compact
+            cache_key = [
+              namespace,
+              name,
+              "#search",
+              ::ActiveRemote::Cached::ArgumentKeys.new(#{sorted_method_args}, __active_remote_cached_options).cache_key
+            ].compact
 
             ::ActiveRemote::Cached.cache.fetch(cache_key, __active_remote_cached_options) do
               if block_given?
@@ -307,7 +339,12 @@ module ActiveRemote
           def self.#{method_name}(#{expanded_method_args}, __active_remote_cached_options = {})
             __active_remote_cached_options = ::ActiveRemote::Cached.default_options.merge(#{cached_finder_options}).merge(__active_remote_cached_options)
             namespace = __active_remote_cached_options.delete(:namespace)
-            cache_key = [namespace, name, "#search", #{sorted_method_args}].compact
+            cache_key = [
+              namespace,
+              name,
+              "#search",
+              ::ActiveRemote::Cached::ArgumentKeys.new(#{sorted_method_args}, __active_remote_cached_options).cache_key
+            ].compact
 
             ::ActiveRemote::Cached.cache.fetch(cache_key, __active_remote_cached_options) do
               results = []

--- a/lib/active_remote/cached/argument_keys.rb
+++ b/lib/active_remote/cached/argument_keys.rb
@@ -1,0 +1,60 @@
+module ActiveRemote::Cached
+  class ArgumentKeys
+    attr_reader :arguments, :argument_string, :options
+
+    REMOVE_CHARACTERS = /[[:space:]+=><{}\[\];:\-,]/
+    REPLACE_MAP = [
+      [" ", "SP"],
+      ["+", "PL"],
+      ["=", "EQ"],
+      [">", "GT"],
+      ["<", "LT"],
+      ["{", "LB"],
+      ["}", "RB"],
+      ["[", "LB2"],
+      ["]", "RB2"],
+      [";", "SC"],
+      [":", "CO"],
+      ["-", "DA"],
+      [",", "COM"],
+    ].freeze
+
+    def initialize(*arguments, options)
+      @options = options
+      @arguments = arguments.flatten.compact
+      @argument_string = ""
+
+      @arguments.each do |argument|
+        @argument_string << "#{argument}"
+      end
+    end
+
+    def cache_key
+      if remove_characters?
+        @argument_string.gsub(REMOVE_CHARACTERS, "")
+      elsif replace_characters?
+        REPLACE_MAP.each do |character, replacement|
+          @argument_string.gsub!(character, replacement)
+        end
+
+        @argument_string
+      else
+        @argument_string
+      end
+    end
+
+    def to_s
+      cache_key
+    end
+
+    private
+
+    def remove_characters?
+      options.fetch(:active_remote_cached_remove_characters, false)
+    end
+
+    def replace_characters?
+      options.fetch(:active_remote_cached_replace_characters, false)
+    end
+  end
+end

--- a/lib/active_remote/cached/argument_keys.rb
+++ b/lib/active_remote/cached/argument_keys.rb
@@ -30,17 +30,14 @@ module ActiveRemote::Cached
     end
 
     def cache_key
-      if remove_characters?
-        @argument_string.gsub(REMOVE_CHARACTERS, "")
-      elsif replace_characters?
+      return @argument_string.gsub(REMOVE_CHARACTERS, "") if remove_characters?
+      if replace_characters?
         REPLACE_MAP.each do |character, replacement|
           @argument_string.gsub!(character, replacement)
         end
-
-        @argument_string
-      else
-        @argument_string
       end
+
+      @argument_string
     end
 
     def to_s

--- a/lib/active_remote/cached/cache.rb
+++ b/lib/active_remote/cached/cache.rb
@@ -56,7 +56,7 @@ module ActiveRemote::Cached
     end
 
     def valid_fetched_value?(value, options = {})
-      return false if value.nil?
+      return false if value.nil? && !options.fetch(:allow_nil, false)
       return false if !options.fetch(:allow_empty, false) && value.respond_to?(:empty?) && value.empty?
       return true
     end

--- a/spec/active_remote/cached/argument_keys_spec.rb
+++ b/spec/active_remote/cached/argument_keys_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe ::ActiveRemote::Cached::ArgumentKeys do
+  it "does not mutate a string by default" do
+    ::ActiveRemote::Cached::ArgumentKeys.new("hello", {}).cache_key.must_equal("hello")
+  end
+
+  it "returns a string of a symbol by default" do
+    ::ActiveRemote::Cached::ArgumentKeys.new(:hello, {}).cache_key.must_equal("hello")
+  end
+
+  it "does not mutate a string with special characters by default" do
+    ::ActiveRemote::Cached::ArgumentKeys.new("hello {}", {}).cache_key.must_equal("hello {}")
+  end
+
+  it "removes special characters from string with special characters when :active_remote_cached_remove_characters" do
+    options = { :active_remote_cached_remove_characters => true }
+    ::ActiveRemote::Cached::ArgumentKeys.new("hello {}", options).cache_key.must_equal("hello")
+  end
+
+  it "replaces special characters from string with special characters when :active_remote_cached_replace_characters" do
+    options = { :active_remote_cached_replace_characters => true }
+    ::ActiveRemote::Cached::ArgumentKeys.new("hello {}", options).cache_key.must_equal("helloSPLBRB")
+  end
+end

--- a/spec/active_remote/cached_find_methods_spec.rb
+++ b/spec/active_remote/cached_find_methods_spec.rb
@@ -79,7 +79,6 @@ describe FindMethodClass do
     end
 
     it "overrides the default options with local options for the fetch call" do
-      $expected = true
       ::ActiveRemote::Cached.cache.expects(:fetch).with([FindMethodClass.name, "#find", "guid"], :expires_in => 200).returns(:hello)
 
       FindMethodClass.stub(:find, :hello) do

--- a/spec/active_remote/cached_find_methods_spec.rb
+++ b/spec/active_remote/cached_find_methods_spec.rb
@@ -71,7 +71,7 @@ describe FindMethodClass do
     end
 
     it "merges the default options in for the fetch call" do
-      ::ActiveRemote::Cached.cache.expects(:fetch).with([FindMethodClass.name, "#find", :guid], :expires_in => 100).returns(:hello)
+      ::ActiveRemote::Cached.cache.expects(:fetch).with([FindMethodClass.name, "#find", "guid"], :expires_in => 100).returns(:hello)
 
       FindMethodClass.stub(:find, :hello) do
         FindMethodClass.cached_find_by_guid(:guid).must_equal(:hello)
@@ -79,7 +79,8 @@ describe FindMethodClass do
     end
 
     it "overrides the default options with local options for the fetch call" do
-      ::ActiveRemote::Cached.cache.expects(:fetch).with([FindMethodClass.name, "#find", :guid], :expires_in => 200).returns(:hello)
+      $expected = true
+      ::ActiveRemote::Cached.cache.expects(:fetch).with([FindMethodClass.name, "#find", "guid"], :expires_in => 200).returns(:hello)
 
       FindMethodClass.stub(:find, :hello) do
         FindMethodClass.cached_find_by_guid(:guid, :expires_in => 200).must_equal(:hello)
@@ -92,7 +93,7 @@ describe FindMethodClass do
       end
 
       it "uses the namespace as a prefix to the cache key" do
-        ::ActiveRemote::Cached.cache.expects(:fetch).with(["MyApp", FindMethodClass.name, "#find", :guid], :expires_in => 100).returns(:hello)
+        ::ActiveRemote::Cached.cache.expects(:fetch).with(["MyApp", FindMethodClass.name, "#find", "guid"], :expires_in => 100).returns(:hello)
 
         FindMethodClass.stub(:find, :hello) do
           FindMethodClass.cached_find_by_guid(:guid)
@@ -112,7 +113,7 @@ describe FindMethodClass do
     end
 
     it "overrides the default options with cached_finder options for the fetch call" do
-      ::ActiveRemote::Cached.cache.expects(:fetch).with([FindMethodClass.name, "#find", :foo], :expires_in => 500).returns(:hello)
+      ::ActiveRemote::Cached.cache.expects(:fetch).with([FindMethodClass.name, "#find", "foo"], :expires_in => 500).returns(:hello)
 
       FindMethodClass.stub(:find, :hello) do
         FindMethodClass.cached_find_by_foo(:foo).must_equal(:hello)
@@ -120,7 +121,7 @@ describe FindMethodClass do
     end
 
     it "overrides the cached_finder options with local options for the fetch call" do
-      ::ActiveRemote::Cached.cache.expects(:fetch).with([FindMethodClass.name, "#find", :foo], :expires_in => 200).returns(:hello)
+      ::ActiveRemote::Cached.cache.expects(:fetch).with([FindMethodClass.name, "#find", "foo"], :expires_in => 200).returns(:hello)
 
       FindMethodClass.stub(:find, :hello) do
         FindMethodClass.cached_find_by_foo(:foo, :expires_in => 200).must_equal(:hello)

--- a/spec/active_remote/cached_search_methods_spec.rb
+++ b/spec/active_remote/cached_search_methods_spec.rb
@@ -95,13 +95,23 @@ describe SearchMethodClass do
       end
     end
 
-    it "does not persist nil values" do
+    it "does not persist nil values by default" do
       SearchMethodClass.stub(:derp, nil) do
         SearchMethodClass.cached_search(:guid => :guid) do
           SearchMethodClass.derp
         end
 
         SearchMethodClass.cached_exist_search_by_guid?(:guid).must_equal(false)
+      end
+    end
+
+    it "persists nil values when allow_nil sent" do
+      SearchMethodClass.stub(:derp, nil) do
+        SearchMethodClass.cached_search({:guid => :guid}, :allow_nil => true) do
+          SearchMethodClass.derp
+        end
+
+        SearchMethodClass.cached_exist_search_by_guid?(:guid).must_equal(true)
       end
     end
 
@@ -128,7 +138,7 @@ describe SearchMethodClass do
     end
 
     it "merges the default options in for the fetch call" do
-      ::ActiveRemote::Cached.cache.expects(:fetch).with([SearchMethodClass.name, "#search", :guid], :expires_in => 100).returns(:hello)
+      ::ActiveRemote::Cached.cache.expects(:fetch).with([SearchMethodClass.name, "#search", "guid"], :expires_in => 100).returns(:hello)
 
       SearchMethodClass.stub(:search, :hello) do
         SearchMethodClass.cached_search_by_guid(:guid).must_equal(:hello)
@@ -136,7 +146,7 @@ describe SearchMethodClass do
     end
 
     it "overrides the default options with local options for the fetch call" do
-      ::ActiveRemote::Cached.cache.expects(:fetch).with([SearchMethodClass.name, "#search", :guid], :expires_in => 200).returns(:hello)
+      ::ActiveRemote::Cached.cache.expects(:fetch).with([SearchMethodClass.name, "#search", "guid"], :expires_in => 200).returns(:hello)
 
       SearchMethodClass.stub(:search, :hello) do
         SearchMethodClass.cached_search_by_guid(:guid, :expires_in => 200).must_equal(:hello)
@@ -149,7 +159,7 @@ describe SearchMethodClass do
       end
 
       it "uses the namespace as a prefix to the cache key" do
-        ::ActiveRemote::Cached.cache.expects(:fetch).with(["MyApp", SearchMethodClass.name, "#search", :guid], :expires_in => 100).returns(:hello)
+        ::ActiveRemote::Cached.cache.expects(:fetch).with(["MyApp", SearchMethodClass.name, "#search", "guid"], :expires_in => 100).returns(:hello)
 
         SearchMethodClass.stub(:search, :hello) do
           SearchMethodClass.cached_search_by_guid(:guid)
@@ -169,7 +179,7 @@ describe SearchMethodClass do
     end
 
     it "overrides the default options with cached_finder options for the fetch call" do
-      ::ActiveRemote::Cached.cache.expects(:fetch).with([SearchMethodClass.name, "#search", :foo], :expires_in => 500).returns(:hello)
+      ::ActiveRemote::Cached.cache.expects(:fetch).with([SearchMethodClass.name, "#search", "foo"], :expires_in => 500).returns(:hello)
 
       SearchMethodClass.stub(:find, :hello) do
         SearchMethodClass.cached_search_by_foo(:foo).must_equal(:hello)
@@ -177,7 +187,7 @@ describe SearchMethodClass do
     end
 
     it "overrides the cached_finder options with local options for the fetch call" do
-      ::ActiveRemote::Cached.cache.expects(:fetch).with([SearchMethodClass.name, "#search", :foo], :expires_in => 200).returns(:hello)
+      ::ActiveRemote::Cached.cache.expects(:fetch).with([SearchMethodClass.name, "#search", "foo"], :expires_in => 200).returns(:hello)
 
       SearchMethodClass.stub(:find, :hello) do
         SearchMethodClass.cached_search_by_foo(:foo, :expires_in => 200).must_equal(:hello)


### PR DESCRIPTION
Add ability to have nils cached (we previously optionally allowed `empty` but didn't extend to `nil`)

also add optional ability to replace or remove "special" characters; decided to add the option to replace because the presence and position of a character may be significant in the calculation of a cache key in some cases; figure we will use replace, but leaving it open

@film42 @liveh2o @mmmries 