### PR TITLE
Fix _method_missing_name to allow numbers

### DIFF
--- a/lib/active_remote/cached.rb
+++ b/lib/active_remote/cached.rb
@@ -95,7 +95,7 @@ module ActiveRemote
       # Underscored Methods
       #
       def _method_missing_name(m)
-        regex = /(cached_(?:delete|exist_search|search|exist_find|find)_by_)([a-zA-Z_]*)(!|\?)?/
+        regex = /(cached_(?:delete|exist_search|search|exist_find|find)_by_)([0-9a-zA-Z_]*)(!|\?)?/
 
         return unless m.to_s =~ regex
 
@@ -105,7 +105,7 @@ module ActiveRemote
 
       # rubocop:disable Metrics/AbcSize
       def _args_in_sorted_order(m, args)
-        regex = /cached_(?:delete|exist_search|search|exist_find|find)_by_([a-zA-Z_]*)(!|\?)?/
+        regex = /cached_(?:delete|exist_search|search|exist_find|find)_by_([0-9a-zA-Z_]*)(!|\?)?/
 
         method_name = _method_missing_name(m)
 

--- a/lib/active_remote/cached/version.rb
+++ b/lib/active_remote/cached/version.rb
@@ -2,6 +2,6 @@
 
 module ActiveRemote
   module Cached
-    VERSION = '1.1.0'
+    VERSION = '1.1.1'
   end
 end

--- a/spec/active_remote/cached_search_methods_spec.rb
+++ b/spec/active_remote/cached_search_methods_spec.rb
@@ -86,7 +86,7 @@ describe SearchMethodClass do
     # method_missing override is used.
     it "can call 'cached_search_by_zippy123_and_alpha' when not defined" do
       expect(SearchMethodClass).to receive(:search)
-      SearchMethodClass.cached_search_by_zippy123_and_alpha("abc", "123")
+      SearchMethodClass.cached_search_by_zippy123_and_alpha('abc', '123')
     end
   end
 
@@ -262,10 +262,10 @@ describe SearchMethodClass do
     end
 
     it 'calls the underlying method with params in correct order' do
-      expect(SearchMethodClass).to receive(:cached_search_by_alpha_and_zippy123).with("123", "abc").and_return(:hello)
+      expect(SearchMethodClass).to receive(:cached_search_by_alpha_and_zippy123).with('123', 'abc').and_return(:hello)
 
       # Calls method that does not exist (different param order)
-      expect(SearchMethodClass.cached_search_by_zippy123_and_alpha("abc", "123")).to eq(:hello)
+      expect(SearchMethodClass.cached_search_by_zippy123_and_alpha('abc', '123')).to eq(:hello)
     end
   end
 end


### PR DESCRIPTION
This fixes an oversight in the regex that matches on missing method names.